### PR TITLE
Microbump libsodium version to get more architectures

### DIFF
--- a/SpaceWizards.Sodium.Interop/SpaceWizards.Sodium.Interop.csproj
+++ b/SpaceWizards.Sodium.Interop/SpaceWizards.Sodium.Interop.csproj
@@ -18,8 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- 1.0.18.2 is just libsodium 1.0.18 but with more architectures added: linux-arm, linux-arm64 in 10.0.18.1,
-      and osx-arm64 in 10.0.18.2. Also support for some older .NETs was dropped in 18.1. -->
     <PackageReference Include="libsodium" Version="1.0.18.2" />
   </ItemGroup>
 

--- a/SpaceWizards.Sodium.Interop/SpaceWizards.Sodium.Interop.csproj
+++ b/SpaceWizards.Sodium.Interop/SpaceWizards.Sodium.Interop.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>SpaceWizards.Sodium.Interop</PackageId>
-    <Version>1.0.18-beta3</Version>
+    <Version>1.0.18-beta4</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Native API binding for libsodium.</Description>
     <NoWarn>CS1591</NoWarn>
@@ -18,7 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="libsodium" Version="1.0.18" />
+    <!-- 1.0.18.2 is just libsodium 1.0.18 but with more architectures added: linux-arm, linux-arm64 in 10.0.18.1,
+      and osx-arm64 in 10.0.18.2. Also support for some older .NETs was dropped in 18.1. -->
+    <PackageReference Include="libsodium" Version="1.0.18.2" />
   </ItemGroup>
 
 </Project>

--- a/SpaceWizards.Sodium/SpaceWizards.Sodium.csproj
+++ b/SpaceWizards.Sodium/SpaceWizards.Sodium.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>SpaceWizards.Sodium</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Simple API binding for libsodium.</Description>
     <NoWarn>CS1591</NoWarn>


### PR DESCRIPTION
As it says in the code comment:
1.0.18.2 is just libsodium 1.0.18 but with more architectures added: linux-arm, linux-arm64 in 10.0.18.1, and osx-arm64 in 10.0.18.2.

Also support for some older .NETs was dropped in 18.1.

Relevant parts of diffs (I trimmed out binary diffs and metadata garbage):
```diff
diff -ur 18/libsodium.nuspec 18.1/libsodium.nuspec
--- 18/libsodium.nuspec	2020-01-06 02:05:34.000000000 +0100
+++ 18.1/libsodium.nuspec	2021-06-13 19:54:52.000000000 +0200
@@ -1,21 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
   <metadata minClientVersion="4.0">
     <id>libsodium</id>
-    <version>1.0.18</version>
+    <version>1.0.18.1</version>
     <authors>Frank Denis</authors>
-    <owners>Frank Denis</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">ISC</license>
     <licenseUrl>https://licenses.nuget.org/ISC</licenseUrl>
     <projectUrl>https://libsodium.org/</projectUrl>
     <description>Internal implementation package not meant for direct consumption. Please do not reference directly.</description>
-    <copyright>© 2020 Frank Denis</copyright>
+    <copyright>© 2021 Frank Denis</copyright>
     <repository type="git" url="https://github.com/jedisct1/libsodium.git" />
-    <dependencies>
-      <group targetFramework=".NETStandard1.1">
-        <dependency id="Microsoft.NETCore.Platforms" version="1.0.1" exclude="Build,Analyzers" />
-      </group>
-    </dependencies>
   </metadata>
 </package>
\ No newline at end of file
Only in 18.1/runtimes: linux-arm
Only in 18.1/runtimes: linux-arm64
```

```diff
diff -ur 18.1/libsodium.nuspec 18.2/libsodium.nuspec
--- 18.1/libsodium.nuspec	2021-06-13 19:54:52.000000000 +0200
+++ 18.2/libsodium.nuspec	2022-03-07 16:42:46.000000000 +0100
@@ -2,14 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
   <metadata minClientVersion="4.0">
     <id>libsodium</id>
-    <version>1.0.18.1</version>
+    <version>1.0.18.2</version>
     <authors>Frank Denis</authors>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <license type="expression">ISC</license>
     <licenseUrl>https://licenses.nuget.org/ISC</licenseUrl>
     <projectUrl>https://libsodium.org/</projectUrl>
     <description>Internal implementation package not meant for direct consumption. Please do not reference directly.</description>
-    <copyright>© 2021 Frank Denis</copyright>
+    <copyright>© 2022 Frank Denis</copyright>
     <repository type="git" url="https://github.com/jedisct1/libsodium.git" />
   </metadata>
 </package>
\ No newline at end of file
Only in 18.2/runtimes: osx-arm64
```
